### PR TITLE
Standardize logging and Pushover handling

### DIFF
--- a/sh/common.sh
+++ b/sh/common.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Common helpers for Edo Pi shell scripts.
+
+set -euo pipefail
+
+PUSHOVER_API_URL=${PUSHOVER_API_URL:-"https://api.pushover.net/1/messages.json"}
+CONFIG_FILE=${CONFIG_FILE:-"$HOME/.pushover/config"}
+LOG_FILE=${LOG_FILE:-"$HOME/.pushover/api.log"}
+
+ensure_log_file() {
+  mkdir -p "$(dirname "$LOG_FILE")"
+  touch "$LOG_FILE"
+}
+
+log_info() {
+  local message=$1
+  ensure_log_file
+  printf '%s [INFO] %s\n' "$(date --iso-8601=seconds)" "$message" | tee -a "$LOG_FILE" >&2
+}
+
+log_error() {
+  local message=$1
+  ensure_log_file
+  printf '%s [ERROR] %s\n' "$(date --iso-8601=seconds)" "$message" | tee -a "$LOG_FILE" >&2
+}
+
+trap_errors() {
+  trap 'log_error "Script ${0##*/} failed at line ${LINENO}."' ERR
+}
+
+load_pushover_config() {
+  if [[ ! -f "$CONFIG_FILE" ]]; then
+    log_error "Pushover config not found at $CONFIG_FILE"
+    exit 1
+  fi
+
+  # shellcheck source=/dev/null
+  source "$CONFIG_FILE"
+
+  if [[ -z "${EDO_ACCESS_TOKEN:-}" || -z "${USER_KEY:-}" ]]; then
+    log_error "EDO_ACCESS_TOKEN or USER_KEY is missing from the config."
+    exit 1
+  fi
+}
+
+send_pushover() {
+  local message=$1
+  local title=${2:-"Edo Pi Notification"}
+  local subject=${3:-""}
+
+  local -a curl_args=(
+    -sS -X POST "$PUSHOVER_API_URL"
+    --form-string "token=$EDO_ACCESS_TOKEN"
+    --form-string "user=$USER_KEY"
+    --form-string "message=$message"
+  )
+
+  [[ -n "$title" ]] && curl_args+=(--form-string "title=$title")
+  [[ -n "$subject" ]] && curl_args+=(--form-string "subject=$subject")
+
+  local response
+  if ! response=$(curl "${curl_args[@]}" 2>&1); then
+    log_error "Failed to send Pushover message: $response"
+    return 1
+  fi
+
+  log_info "Pushover message sent (${title:-no title})."
+  echo "$response" >> "$LOG_FILE"
+}

--- a/sh/reboot.sh
+++ b/sh/reboot.sh
@@ -1,28 +1,22 @@
 #!/bin/bash
 
-# Load Pushover config
-source ~/.pushover/config
+set -euo pipefail
 
-# API URL for Pushover
-api_url="https://api.pushover.net/1/messages.json"
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "$SCRIPT_DIR/common.sh"
 
-# Application key and user key (from config file)
-app_token="$EDO_ACCESS_TOKEN"
-user_key="$USER_KEY"
+trap_errors
+load_pushover_config
 
-# Get uptime and convert it to hours and minutes
-uptime=$($HOME/sh/uptime.sh)
+if [[ -x "$HOME/sh/uptime.sh" ]]; then
+    uptime=$($HOME/sh/uptime.sh)
+else
+    uptime=$(uptime -p | sed 's/^up //')
+fi
 
-# Message to send
 message="I've been up for $uptime, so I'm going to take a quick rest... See you soon!"
 
-# Post to Pushover using curl and log the output
-curl -s -X POST \
-    --form-string "token=$app_token" \
-    --form-string "user=$user_key" \
-    --form-string "message=$message" \
-    --form-string "subject=Reboot" \
-    $api_url
+send_pushover "$message" "Reboot" "Reboot"
+log_info "Reboot notification sent."
 
-# Reboot the system
 sudo reboot

--- a/sh/update.sh
+++ b/sh/update.sh
@@ -22,7 +22,7 @@ end_time=$(date +%s)
 upgrade_duration=$((end_time - start_time))
 log_info "apt-get upgrade completed in ${upgrade_duration}s."
 
-upgraded_packages=$(grep -oP 'Setting up \K[^ ]+' /tmp/apt_upgrade.log | wc -l)
+upgraded_packages=$(grep -cP 'Setting up \K[^ ]+' /tmp/apt_upgrade.log || true)
 
 if [ "$upgraded_packages" -eq 0 ]; then
     message="I just spent ${update_duration} seconds updating my package list and ${upgrade_duration} seconds upgrading nothing at all!"


### PR DESCRIPTION
## Summary
- add shared helper for loading Pushover secrets, logging, and error trapping
- update Pi maintenance scripts to rely on the common helper for messaging
- add consistent logging for update, disk, reboot, and torrent-check workflows

## Testing
- bash -n sh/common.sh sh/update.sh sh/reboot.sh sh/free_space.sh sh/getraspios.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a41fc75a4832bb32db2a9302b7f90)