### PR TITLE
Add bootstrap timer to keep systemd units in sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ With the timer enabled, the Pi continually pulls the latest repo changes and re-
 
 The following timers mirror the previous crontab on the Pi:
 
-- `systemd/edo-start-up.timer`: runs `/home/edo/sh/start-up.sh` once after boot with a 30s delay (replaces `@reboot`).
-- `systemd/edo-rpi.timer`: runs `/home/edo/rpi/rpi.sh` hourly (replaces `0 * * * *`).
-- `systemd/edo-update.timer`: runs `/home/edo/sh/update.sh` daily at 01:00 (replaces `0 1 * * *`).
-- `systemd/edo-reboot.timer`: runs `/home/edo/sh/reboot.sh` Fridays at 02:00 (replaces `0 2 * * 5`).
-- `systemd/edo-free-space.timer`: runs `/home/edo/sh/free_space.sh` daily at 03:00 (replaces `0 3 * * *`).
+- `systemd/edo-start-up.timer`: runs `/home/edo/rpi/sh/start-up.sh` once after boot with a 30s delay (replaces `@reboot`).
+- `systemd/edo-rpi.timer`: runs `/home/edo/rpi/sh/rpi.sh` hourly (replaces `0 * * * *`).
+- `systemd/edo-update.timer`: runs `/home/edo/rpi/sh/update.sh` daily at 01:00 (replaces `0 1 * * *`).
+- `systemd/edo-reboot.timer`: runs `/home/edo/rpi/sh/reboot.sh` Fridays at 02:00 (replaces `0 2 * * 5`).
+- `systemd/edo-free-space.timer`: runs `/home/edo/rpi/sh/free_space.sh` daily at 03:00 (replaces `0 3 * * *`).
 
 All timers live in `systemd/` so they stay version-controlled and are picked up automatically by `sh/bootstrap-install.sh` and `sh/git-self-update.sh`.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ Edo is a Raspberry Pi that lives in a closet and hosts Raspbian torrents. These 
 
 With the timer enabled, the Pi continually pulls the latest repo changes and re-applies any updated systemd units without further SSH access.
 
+## Pilot log review configuration
+
+- Pushover credentials are loaded from `$HOME/.pushover/config` (or the `CONFIG_FILE` override) and must provide `EDO_ACCESS_TOKEN` and `USER_KEY`.
+- Pilot will source `$HOME/.openai/config` (or `OPENAI_CONFIG`) to populate `OPENAI_API_KEY` if it is not already set in the environment. The config file must define `OPENAI_API_KEY`.
+
 ## Replacing legacy cron jobs
 
 The following timers mirror the previous crontab on the Pi:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
 # edo
-Edo is a raspberry pi that lives in my closet and hosts raspbian torrents. These are the scripts and files that make it work.
+
+Edo is a Raspberry Pi that lives in a closet and hosts Raspbian torrents. These scripts keep it updated and self-managing without manual SSH once the initial setup is done.
+
+## Bootstrap install (run once)
+
+1. Clone the repository to `/home/edo/rpi` on the Pi.
+2. From the repo root run `./sh/bootstrap-install.sh`.
+   - Copies `systemd/*.service` and `systemd/*.timer` files to `/etc/systemd/system/`.
+   - Reloads systemd and enables/starts every timer found in `systemd/`.
+
+## Automated updates
+
+- `systemd/edo-git-update.timer` triggers `systemd/edo-git-update.service` every 30 minutes (and shortly after boot).
+- The service runs `sh/git-self-update.sh`, which:
+  1. Runs `git pull` in `/home/edo/rpi`.
+  2. Checks for changes under `systemd/` between the previous and current HEAD.
+  3. Re-runs `sh/bootstrap-install.sh` automatically if systemd units changed.
+
+- `systemd/edo-bootstrap-install.timer` runs `sh/bootstrap-install.sh` every hour (and shortly after boot) to forcibly re-copy
+  all versioned systemd units into `/etc/systemd/system/` and reload systemd. This keeps systemd in sync even if new timers
+  are added without a prior Git pull or if a manual change drifts from the repo.
+
+With the timer enabled, the Pi continually pulls the latest repo changes and re-applies any updated systemd units without further SSH access.
+
+## Replacing legacy cron jobs
+
+The following timers mirror the previous crontab on the Pi:
+
+- `systemd/edo-start-up.timer`: runs `/home/edo/sh/start-up.sh` once after boot with a 30s delay (replaces `@reboot`).
+- `systemd/edo-rpi.timer`: runs `/home/edo/rpi/rpi.sh` hourly (replaces `0 * * * *`).
+- `systemd/edo-update.timer`: runs `/home/edo/sh/update.sh` daily at 01:00 (replaces `0 1 * * *`).
+- `systemd/edo-reboot.timer`: runs `/home/edo/sh/reboot.sh` Fridays at 02:00 (replaces `0 2 * * 5`).
+- `systemd/edo-free-space.timer`: runs `/home/edo/sh/free_space.sh` daily at 03:00 (replaces `0 3 * * *`).
+
+All timers live in `systemd/` so they stay version-controlled and are picked up automatically by `sh/bootstrap-install.sh` and `sh/git-self-update.sh`.

--- a/sh/bootstrap-install.sh
+++ b/sh/bootstrap-install.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_DIR=${REPO_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}
+SYSTEMD_SRC="$REPO_DIR/systemd"
+
+source "$SCRIPT_DIR/common.sh"
+trap_errors
+
+log_info "Installing systemd units from $SYSTEMD_SRC."
+
+if [[ ! -d "$SYSTEMD_SRC" ]]; then
+  log_error "Systemd directory not found at $SYSTEMD_SRC."
+  exit 1
+fi
+
+mapfile -t unit_files < <(find "$SYSTEMD_SRC" -maxdepth 1 -type f \( -name '*.service' -o -name '*.timer' \))
+
+if [[ ${#unit_files[@]} -eq 0 ]]; then
+  log_error "No systemd unit files found in $SYSTEMD_SRC."
+  exit 1
+fi
+
+for unit in "${unit_files[@]}"; do
+  unit_name=$(basename "$unit")
+  log_info "Installing $unit_name to /etc/systemd/system/."
+  sudo install -m 644 "$unit" "/etc/systemd/system/$unit_name"
+done
+
+log_info "Reloading systemd units."
+sudo systemctl daemon-reload
+
+for timer in "${unit_files[@]}"; do
+  if [[ "$timer" == *.timer ]]; then
+    timer_name=$(basename "$timer")
+    log_info "Enabling and starting $timer_name."
+    sudo systemctl enable --now "$timer_name"
+  fi
+fi
+
+log_info "Systemd unit installation complete."

--- a/sh/common.sh
+++ b/sh/common.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 PUSHOVER_API_URL=${PUSHOVER_API_URL:-"https://api.pushover.net/1/messages.json"}
 CONFIG_FILE=${CONFIG_FILE:-"$HOME/.pushover/config"}
 LOG_FILE=${LOG_FILE:-"$HOME/.pushover/api.log"}
+OPENAI_CONFIG=${OPENAI_CONFIG:-"$HOME/.openai/config"}
 
 ensure_log_file() {
   mkdir -p "$(dirname "$LOG_FILE")"
@@ -66,4 +67,23 @@ send_pushover() {
 
   log_info "Pushover message sent (${title:-no title})."
   echo "$response" >> "$LOG_FILE"
+}
+
+load_openai_config() {
+  if [[ -n "${OPENAI_API_KEY:-}" ]]; then
+    return
+  fi
+
+  if [[ -f "$OPENAI_CONFIG" ]]; then
+    # shellcheck source=/dev/null
+    source "$OPENAI_CONFIG"
+  else
+    log_error "OpenAI config not found at $OPENAI_CONFIG and OPENAI_API_KEY is not set."
+    exit 1
+  fi
+
+  if [[ -z "${OPENAI_API_KEY:-}" ]]; then
+    log_error "OPENAI_API_KEY is missing from $OPENAI_CONFIG."
+    exit 1
+  fi
 }

--- a/sh/git-self-update.sh
+++ b/sh/git-self-update.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_DIR=${REPO_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}
+SYSTEMD_DIR="$REPO_DIR/systemd"
+
+source "$SCRIPT_DIR/common.sh"
+trap_errors
+
+log_info "Starting git self-update for $REPO_DIR."
+
+if [[ ! -d "$REPO_DIR" ]]; then
+  log_error "Repository directory $REPO_DIR does not exist."
+  exit 1
+fi
+
+cd "$REPO_DIR"
+previous_ref=$(git rev-parse HEAD)
+
+log_info "Running git pull in $REPO_DIR."
+git pull
+
+current_ref=$(git rev-parse HEAD)
+
+if [[ "$previous_ref" == "$current_ref" ]]; then
+  log_info "Repository already up to date."
+  exit 0
+fi
+
+log_info "Repository updated from $previous_ref to $current_ref. Checking for systemd unit changes."
+if git diff --name-only "$previous_ref" "$current_ref" | grep -q '^systemd/'; then
+  log_info "Systemd units changed; reinstalling."
+  "$SCRIPT_DIR/bootstrap-install.sh"
+else
+  log_info "No systemd changes detected."
+fi
+
+log_info "Git self-update complete."

--- a/sh/pilot.sh
+++ b/sh/pilot.sh
@@ -8,8 +8,7 @@ source "$SCRIPT_DIR/common.sh"
 
 trap_errors
 load_pushover_config
-
-: "${OPENAI_API_KEY:?Environment variable OPENAI_API_KEY is required.}"
+load_openai_config
 
 if ! command -v jq >/dev/null 2>&1; then
   log_error "jq is required to run Pilot."

--- a/sh/rpi.sh
+++ b/sh/rpi.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "$SCRIPT_DIR/common.sh"
+
+trap_errors
+
+log_info "Running hourly maintenance hook (customize sh/rpi.sh as needed)."
+
+# Insert hourly maintenance tasks below. The placeholder keeps the systemd
+# service healthy until real work is added.
+
+exit 0

--- a/sh/start-up.sh
+++ b/sh/start-up.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "$SCRIPT_DIR/common.sh"
+
+trap_errors
+
+log_info "Running startup hook (add custom tasks to sh/start-up.sh)."
+
+# Add any one-time boot actions below. The placeholder ensures the systemd unit
+# succeeds even if no commands are specified yet.
+
+exit 0

--- a/systemd/edo-bootstrap-install.service
+++ b/systemd/edo-bootstrap-install.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Reinstall Edo systemd units from the repository
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/edo/rpi
+ExecStart=/home/edo/rpi/sh/bootstrap-install.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/edo-bootstrap-install.timer
+++ b/systemd/edo-bootstrap-install.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Hourly reinstall of Edo systemd units from the repository
+
+[Timer]
+OnBootSec=3min
+OnUnitActiveSec=1h
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/systemd/edo-free-space.service
+++ b/systemd/edo-free-space.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Daily Edo free space check
+
+[Service]
+Type=oneshot
+User=edo
+ExecStart=/home/edo/sh/free_space.sh

--- a/systemd/edo-free-space.service
+++ b/systemd/edo-free-space.service
@@ -4,4 +4,4 @@ Description=Daily Edo free space check
 [Service]
 Type=oneshot
 User=edo
-ExecStart=/home/edo/sh/free_space.sh
+ExecStart=/home/edo/rpi/sh/free_space.sh

--- a/systemd/edo-free-space.timer
+++ b/systemd/edo-free-space.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Daily Edo free space check (03:00)
+
+[Timer]
+OnCalendar=*-*-* 03:00:00
+Persistent=true
+Unit=edo-free-space.service
+
+[Install]
+WantedBy=timers.target

--- a/systemd/edo-git-update.service
+++ b/systemd/edo-git-update.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Update Edo repository and apply systemd unit changes
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/edo/rpi
+ExecStart=/home/edo/rpi/sh/git-self-update.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/edo-git-update.timer
+++ b/systemd/edo-git-update.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Regularly update Edo repository and systemd units
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=30min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/systemd/edo-reboot.service
+++ b/systemd/edo-reboot.service
@@ -4,4 +4,4 @@ Description=Weekly Edo reboot with notification
 [Service]
 Type=oneshot
 User=edo
-ExecStart=/home/edo/sh/reboot.sh
+ExecStart=/home/edo/rpi/sh/reboot.sh

--- a/systemd/edo-reboot.service
+++ b/systemd/edo-reboot.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Weekly Edo reboot with notification
+
+[Service]
+Type=oneshot
+User=edo
+ExecStart=/home/edo/sh/reboot.sh

--- a/systemd/edo-reboot.timer
+++ b/systemd/edo-reboot.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Weekly Edo reboot (Fridays at 02:00)
+
+[Timer]
+OnCalendar=Fri *-*-* 02:00:00
+Persistent=true
+Unit=edo-reboot.service
+
+[Install]
+WantedBy=timers.target

--- a/systemd/edo-rpi.service
+++ b/systemd/edo-rpi.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Run Edo hourly rpi maintenance script
+
+[Service]
+Type=oneshot
+User=edo
+ExecStart=/home/edo/rpi/rpi.sh

--- a/systemd/edo-rpi.service
+++ b/systemd/edo-rpi.service
@@ -4,4 +4,4 @@ Description=Run Edo hourly rpi maintenance script
 [Service]
 Type=oneshot
 User=edo
-ExecStart=/home/edo/rpi/rpi.sh
+ExecStart=/home/edo/rpi/sh/rpi.sh

--- a/systemd/edo-rpi.timer
+++ b/systemd/edo-rpi.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Hourly Edo rpi maintenance
+
+[Timer]
+OnCalendar=hourly
+Persistent=true
+Unit=edo-rpi.service
+
+[Install]
+WantedBy=timers.target

--- a/systemd/edo-start-up.service
+++ b/systemd/edo-start-up.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run Edo startup script after boot delay
+After=network.target
+
+[Service]
+Type=oneshot
+User=edo
+ExecStart=/bin/bash -lc "/bin/sleep 30; /home/edo/sh/start-up.sh"
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/edo-start-up.service
+++ b/systemd/edo-start-up.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=oneshot
 User=edo
-ExecStart=/bin/bash -lc "/bin/sleep 30; /home/edo/sh/start-up.sh"
+ExecStart=/bin/bash -lc "/bin/sleep 30; /home/edo/rpi/sh/start-up.sh"
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/edo-start-up.timer
+++ b/systemd/edo-start-up.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run Edo startup script after boot
+
+[Timer]
+OnBootSec=30
+Unit=edo-start-up.service
+
+[Install]
+WantedBy=timers.target

--- a/systemd/edo-update.service
+++ b/systemd/edo-update.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Run Edo daily system update
+
+[Service]
+Type=oneshot
+User=edo
+ExecStart=/home/edo/sh/update.sh

--- a/systemd/edo-update.service
+++ b/systemd/edo-update.service
@@ -4,4 +4,4 @@ Description=Run Edo daily system update
 [Service]
 Type=oneshot
 User=edo
-ExecStart=/home/edo/sh/update.sh
+ExecStart=/home/edo/rpi/sh/update.sh

--- a/systemd/edo-update.timer
+++ b/systemd/edo-update.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Daily Edo system update
+
+[Timer]
+OnCalendar=*-*-* 01:00:00
+Persistent=true
+Unit=edo-update.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary
- add a dedicated service/timer that reruns bootstrap-install periodically to ensure new systemd units are installed
- align git self-update unit and documentation with the /home/edo/rpi repository path
- document the bootstrap timer so users know systemd stays synced automatically

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b27c14368832ba9286df96346d041)