### PR TITLE
Fix bootstrap install loop termination

### DIFF
--- a/sh/bootstrap-install.sh
+++ b/sh/bootstrap-install.sh
@@ -38,6 +38,6 @@ for timer in "${unit_files[@]}"; do
     log_info "Enabling and starting $timer_name."
     sudo systemctl enable --now "$timer_name"
   fi
-fi
+done
 
 log_info "Systemd unit installation complete."


### PR DESCRIPTION
## Summary
- fix the timer enabling loop in bootstrap-install.sh to close the for-loop properly

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b39a5fba0832bbf9f9c38e3ecb523)