### PR TITLE
Fix raspios release directory parsing

### DIFF
--- a/sh/getraspios.sh
+++ b/sh/getraspios.sh
@@ -48,7 +48,8 @@ for dir in "${directories[@]}"; do
     printf '%s\n' "$index_html" \
       | grep -oE 'href="[^\"]+/"' \
       | cut -d '"' -f2 \
-      | grep -E '^[0-9]{4}-[0-9]{2}-[0-9]{2}-' \
+      | grep -E '[0-9]{4}-[0-9]{2}-[0-9]{2}' \
+      | grep -vE '^\?' \
       | sort \
       | tail -n 1;
   } || true)


### PR DESCRIPTION
## Summary
- update raspios image directory parsing to match dated directory names with prefixes
- ignore query links when determining the newest release before fetching torrents

## Testing
- bash -n sh/getraspios.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b9960b4c0832b97f01517115c6065)