### PR TITLE
Fix Pilot response format for OpenAI API

### DIFF
--- a/sh/pilot.sh
+++ b/sh/pilot.sh
@@ -95,7 +95,7 @@ call_openai() {
 
   local payload
   payload=$(jq -n --arg model "$OPENAI_MODEL" --arg system "$prompt" --arg user "$content" \
-    '{model: $model, input: [{role: "system", content: $system}, {role: "user", content: $user}], max_output_tokens: 350, response_format: {type: "text"}}')
+    '{model: $model, input: [{role: "system", content: $system}, {role: "user", content: $user}], max_output_tokens: 350, text: {format: "plain"}}')
 
   local response
   if ! response=$(curl -sS "https://api.openai.com/v1/responses" \


### PR DESCRIPTION
## Summary
- update Pilot payload to use the current OpenAI responses API text format field

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b99c1d114832b8472d9749ca1a5fb)