### PR TITLE
Fix Pilot text format payload

### DIFF
--- a/sh/pilot.sh
+++ b/sh/pilot.sh
@@ -95,7 +95,7 @@ call_openai() {
 
   local payload
   payload=$(jq -n --arg model "$OPENAI_MODEL" --arg system "$prompt" --arg user "$content" \
-    '{model: $model, input: [{role: "system", content: $system}, {role: "user", content: $user}], max_output_tokens: 350, text: {format: "plain"}}')
+    '{model: $model, input: [{role: "system", content: $system}, {role: "user", content: $user}], max_output_tokens: 350, text: {format: {type: "text"}}}')
 
   local response
   if ! response=$(curl -sS "https://api.openai.com/v1/responses" \


### PR DESCRIPTION
## Summary
- configure Pilot's OpenAI payload to use the text.format object for plain text responses
- keep existing log collection, prompt building, and message parsing unchanged

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b9a33f840832bae90f9e8f2baa7f7)