### PR TITLE
Fix Pilot parsing for OpenAI responses

### DIFF
--- a/sh/pilot.sh
+++ b/sh/pilot.sh
@@ -106,7 +106,11 @@ call_openai() {
   fi
 
   local message
-  message=$(echo "$response" | jq -r '.output[0].content[0].text // empty')
+  message=$(echo "$response" | jq -r '
+    .output // []
+    | (map(select(.type == "message"))[0].content[0].text //
+       map(select(.type == "output_text"))[0].text // empty)
+  ')
 
   if [[ -z "$message" ]]; then
     message=$(echo "$response" | jq -r '.choices[0].message.content // empty')


### PR DESCRIPTION
## Summary
- update Pilot OpenAI response parsing to handle modern response structures
- keep fallback to legacy chat completions when parsing message content

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b9b2dc730832bb8fd342e547cc4fc)