### PR TITLE
Handle HOME fallback for systemd scripts

### DIFF
--- a/sh/common.sh
+++ b/sh/common.sh
@@ -3,6 +3,10 @@
 
 set -euo pipefail
 
+# Default HOME is not guaranteed when run under systemd units that clear the
+# environment. Fall back to the Edo user path to keep config/log paths stable.
+HOME=${HOME:-/home/edo}
+
 PUSHOVER_API_URL=${PUSHOVER_API_URL:-"https://api.pushover.net/1/messages.json"}
 CONFIG_FILE=${CONFIG_FILE:-"$HOME/.pushover/config"}
 LOG_FILE=${LOG_FILE:-"$HOME/.pushover/api.log"}


### PR DESCRIPTION
## Summary
- ensure a default HOME value is set in common.sh to keep config and log paths stable
- prevent systemd-launched scripts from failing due to an unbound HOME variable

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b9c7c3c34832bb5f8424fee3f0a0b)