### PR TITLE
Disable failing gldriver-test units on headless Pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,7 @@ The following timers mirror the previous crontab on the Pi:
 - `systemd/edo-free-space.timer`: runs `/home/edo/rpi/sh/free_space.sh` daily at 03:00 (replaces `0 3 * * *`).
 
 All timers live in `systemd/` so they stay version-controlled and are picked up automatically by `sh/bootstrap-install.sh` and `sh/git-self-update.sh`.
+
+## GL driver test cleanup
+
+`sh/start-up.sh` disables the stock `gldriver-test.service`/`.timer` pair if they exist. The default service references `/usr/share/X11/xorg.conf.d/99-fbturbo.conf`, which is absent on headless builds and produces recurring failures in `journalctl -u gldriver-test`.

--- a/sh/start-up.sh
+++ b/sh/start-up.sh
@@ -9,7 +9,35 @@ trap_errors
 
 log_info "Running startup hook (add custom tasks to sh/start-up.sh)."
 
-# Add any one-time boot actions below. The placeholder ensures the systemd unit
-# succeeds even if no commands are specified yet.
+disable_gldriver_test() {
+  local service="gldriver-test.service"
+  local timer="gldriver-test.timer"
 
-exit 0
+  log_info "Checking for legacy GL driver test units."
+
+  if systemctl list-unit-files "$service" >/dev/null 2>&1; then
+    if systemctl is-enabled "$service" >/dev/null 2>&1; then
+      log_info "Disabling $service because it fails on headless setups."
+      sudo systemctl disable --now "$service"
+    else
+      log_info "$service already disabled or static."
+    fi
+  else
+    log_info "$service not installed; nothing to do."
+  fi
+
+  if systemctl list-unit-files "$timer" >/dev/null 2>&1; then
+    if systemctl is-enabled "$timer" >/dev/null 2>&1; then
+      log_info "Disabling $timer to stop recurring failures."
+      sudo systemctl disable --now "$timer"
+    else
+      log_info "$timer already disabled or static."
+    fi
+  else
+    log_info "$timer not installed; nothing to do."
+  fi
+}
+
+disable_gldriver_test
+
+log_info "Startup hook complete."


### PR DESCRIPTION
## Summary
- add startup automation to disable the stock gldriver-test service/timer
- document the change and explain why the legacy unit fails on headless builds

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b9e9a3d1c832b9525a2ef6764e115)