### PR TITLE
Run systemd services as root

### DIFF
--- a/systemd/edo-free-space.service
+++ b/systemd/edo-free-space.service
@@ -3,5 +3,4 @@ Description=Daily Edo free space check
 
 [Service]
 Type=oneshot
-User=edo
 ExecStart=/home/edo/rpi/sh/free_space.sh

--- a/systemd/edo-reboot.service
+++ b/systemd/edo-reboot.service
@@ -3,5 +3,4 @@ Description=Weekly Edo reboot with notification
 
 [Service]
 Type=oneshot
-User=edo
 ExecStart=/home/edo/rpi/sh/reboot.sh

--- a/systemd/edo-rpi.service
+++ b/systemd/edo-rpi.service
@@ -3,5 +3,4 @@ Description=Run Edo hourly rpi maintenance script
 
 [Service]
 Type=oneshot
-User=edo
 ExecStart=/home/edo/rpi/sh/rpi.sh

--- a/systemd/edo-start-up.service
+++ b/systemd/edo-start-up.service
@@ -4,7 +4,6 @@ After=network.target
 
 [Service]
 Type=oneshot
-User=edo
 ExecStart=/bin/bash -lc "/bin/sleep 30; /home/edo/rpi/sh/start-up.sh"
 
 [Install]

--- a/systemd/edo-update.service
+++ b/systemd/edo-update.service
@@ -3,5 +3,4 @@ Description=Run Edo daily system update
 
 [Service]
 Type=oneshot
-User=edo
 ExecStart=/home/edo/rpi/sh/update.sh


### PR DESCRIPTION
## Summary
- remove user overrides from systemd services so they run with root privileges by default
- update bootstrap installer to copy units and enable timers using the documented commands

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b9fc10a50832bbd88b566ed1d6bcd)